### PR TITLE
New Github Actions to build and release BaM

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,4 +1,4 @@
-name: Compile exes with makefile
+name: Build on Windows
 
 on:
   workflow_dispatch:

--- a/.github/workflows/windows-linux-build-release.yml
+++ b/.github/workflows/windows-linux-build-release.yml
@@ -1,0 +1,77 @@
+name: Build on Windows and Linux and create a release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on:  ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+        include:
+          - os: windows-latest
+            test_cmd: .\BaM.exe --version
+          - os: ubuntu-latest
+            test_cmd: ./BaM --version
+
+    steps:
+      - uses: actions/checkout@v4
+          
+      - name: Verify gfortran
+        run: gfortran --version
+
+      - name: Install dependencies
+        run: |
+          cd ..
+          git clone https://github.com/benRenard/miniDMSL.git miniDMSL 
+          git clone https://github.com/benRenard/BMSL.git BMSL 
+
+      - name: Call make
+        run: |
+          cd makefile
+          make
+
+      - name: Test executable
+        run: |
+          cd makefile
+          ${{ matrix.test_cmd }}
+
+      - name: Rename artifact (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          cd makefile/
+          mv BaM BaM-${VERSION}-linux
+
+      - name: Rename artifact (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          $version = "${env:GITHUB_REF}".Replace("refs/tags/", "")
+          cd makefile
+          Rename-Item BaM.exe "BaM-$version-windows.exe"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: BaM-${{ matrix.os }}
+          path: makefile/BaM-*
+          
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: BaM ${{ github.ref_name }}
+          generate_release_notes: true
+          files: artifacts/**/*
+

--- a/.github/workflows/windows-linux-macos-build.yml
+++ b/.github/workflows/windows-linux-macos-build.yml
@@ -1,0 +1,63 @@
+name: Build on Windows, Linux and MacOS
+
+# Build on MacOS currently fails with the following error: 
+
+# ld: library 'crt0.o' not found
+# collect2: error: ld returned 1 exit status
+# make: *** [build_exe] Error 1
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        include:
+          - os: windows-latest
+            exe_name: BaM.exe
+            test_cmd: .\BaM.exe --version
+          - os: ubuntu-latest
+            exe_name: BaM
+            test_cmd: ./BaM --version
+          - os: macos-latest
+            exe_name: BaM
+            test_cmd: ./BaM --version
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install gfortran (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew update
+          brew install gcc
+          GF_BIN="$(ls $(brew --prefix)/bin/gfortran* 2>/dev/null | sort -V | tail -n1)"
+          if [ -z "$GF_BIN" ]; then
+            echo "gfortran binary not found in $(brew --prefix)/bin" >&2
+            exit 1
+          fi
+          sudo ln -sf "$GF_BIN" /usr/local/bin/gfortran
+          echo "Symlinked $GF_BIN -> /usr/local/bin/gfortran"
+          
+      - name: Verify gfortran
+        run: gfortran --version
+
+      - name: Install dependencies
+        run: |
+          cd ..
+          git clone https://github.com/benRenard/miniDMSL.git miniDMSL 
+          git clone https://github.com/benRenard/BMSL.git BMSL 
+
+      - name: Call make
+        run: |
+          cd makefile
+          make
+
+      - name: Test executable
+        run: |
+          cd makefile
+          ${{ matrix.test_cmd }}

--- a/makefile/makefile
+++ b/makefile/makefile
@@ -1,5 +1,5 @@
 #========================================================================
-# Makefile to build BaM for LINUX based on MiniDMSL
+# Makefile to build BaM for LINUX/WINDOWS/MACOS based on MiniDMSL
 #========================================================================
 #
 

--- a/makefile/makefile
+++ b/makefile/makefile
@@ -5,7 +5,7 @@
 
 # Define the Fortran Compiler and its options
 FC  = gfortran
-FLAGS = -fcheck=all -Wall -O3 # DEBUG: -fcheck=all -Wall -g -O0
+FLAGS = -fcheck=all -Wall -O3 -static # DEBUG: -fcheck=all -Wall -g -O0
 
 # Define directories
 DMSL_DIR = ../../miniDMSL/src/


### PR DESCRIPTION
This PR aims at addressing issue #20 by suggesting a new Github Action that
- build BaM for both windows and linux
- create a new release when the action is triggered with a tag push

Here is a typical workflow: 
- you've commited and pushed all your changes including the update of the version string in the main.f90 src file
- on your local machine you create a new tag using `git tag v1.1.2`
- you then push the tag to the remote with `git push origin v1.1.2`
- this triggers the github action and create a new release: 
  - named "BaM v1.1.2"
  - with two assets attached "BaM-v1.1.2-linux" and "BaM-v1.1.2-windows.exe" which are the two executables
  - a link to a full change log since the last release
  - this release can be edited afterwards with some custom text to better describe the main changes

This PR also includes:
- the `-static` flag in the makefile so the exe created are fully static (this is the fix of issue #20 for windows)
- a change in the header title comment of the makefile to indicate it can also be using on windows and MacOS
- another Github action that shows my attempt at building BaM on MacOS but with no success so far
- a rename of the original "makefile" Github action to better reflect its purpose
